### PR TITLE
Filename download fix

### DIFF
--- a/docs/common.js
+++ b/docs/common.js
@@ -237,6 +237,8 @@ window.toggleLayer = function(layerType, table) {
 }
 
 window.loadUrl = function(url, loadingElement, gpName) {
+  fileName = url.split('/').pop();
+  console.log(fileName)
   loadingElement.toggle();
   var xhr = new XMLHttpRequest();
   xhr.open('GET', url, true);

--- a/docs/common.js
+++ b/docs/common.js
@@ -238,7 +238,6 @@ window.toggleLayer = function(layerType, table) {
 
 window.loadUrl = function(url, loadingElement, gpName) {
   fileName = url.split('/').pop();
-  console.log(fileName)
   loadingElement.toggle();
   var xhr = new XMLHttpRequest();
   xhr.open('GET', url, true);


### PR DESCRIPTION
In common.js in the docs page, the filename property is never updated when loading one of the sample geopackages (from url). This causes the download as geopackage button to send a file with an incorrect name to the user (it sends the right file, but with the name of the last loaded geopackage).

This is just a quick fix that works for the provided sample geopackages.