### PR TITLE
Adjusting module paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var wkx = require('wkx')
   , fs = require('fs');
 
 var GeoPackageManager = require('./lib/geoPackageManager')
-  , GeoPackage = require('./lib/geopackage')
+  , GeoPackage = require('./lib/geoPackage')
   , GeoPackageTileRetriever = require('./lib/tiles/retriever')
   , GeoPackageConnection = require('./lib/db/geoPackageConnection')
   , BoundingBox = require('./lib/boundingBox')

--- a/lib/features/user/featureDao.js
+++ b/lib/features/user/featureDao.js
@@ -3,7 +3,7 @@
  * @module features/user/featureDao
  */
 
-var UserDao = require('../../user/UserDao')
+var UserDao = require('../../user/userDao')
   , GeometryColumnsDao = require('../columns').GeometryColumnsDao
   , ContentsDao = require('../../core/contents').ContentsDao
   , FeatureRow = require('./featureRow');

--- a/lib/features/user/featureRow.js
+++ b/lib/features/user/featureRow.js
@@ -3,7 +3,7 @@
  * @module features/user/featureRow
  */
 
-var UserRow = require('../../user/UserRow')
+var UserRow = require('../../user/userRow')
   , FeatureColumn = require('./featureColumn')
   , GeometryData = require('../../geom/geometryData');
 

--- a/lib/features/user/featureTableReader.js
+++ b/lib/features/user/featureTableReader.js
@@ -3,7 +3,7 @@
  * @module features/user/featureTableReader
  */
 
-var UserTableReader = require('../../user/UserTableReader')
+var UserTableReader = require('../../user/userTableReader')
   , FeatureTable = require('./featureTable')
   , FeatureColumn = require('./featureColumn')
   , GeometryColumnsDao = require('../columns').GeometryColumnsDao

--- a/lib/tiles/user/tileDao.js
+++ b/lib/tiles/user/tileDao.js
@@ -3,7 +3,7 @@
  * @module tiles/user/tileDao
  */
 
-var UserDao = require('../../user/UserDao')
+var UserDao = require('../../user/userDao')
   , TileGrid = require('../tileGrid')
   , TileRow = require('./tileRow')
   , TileMatrixSetDao = require('../matrixset').TileMatrixSetDao

--- a/lib/tiles/user/tileRow.js
+++ b/lib/tiles/user/tileRow.js
@@ -3,7 +3,7 @@
  * @module tiles/user/tileRow
  */
 
-var UserRow = require('../../user/UserRow');
+var UserRow = require('../../user/userRow');
 
 var util = require('util');
 

--- a/lib/tiles/user/tileTableReader.js
+++ b/lib/tiles/user/tileTableReader.js
@@ -3,7 +3,7 @@
  * @module tiles/user/tileTableReader
  */
 
-var UserTableReader = require('../../user/UserTableReader')
+var UserTableReader = require('../../user/userTableReader')
   , DataTypes = require('../../db/dataTypes')
   , TileMatrixSet = require('../matrixset').TileMatrixSet
   , TileTable = require('./tileTable')


### PR DESCRIPTION
Right now, geopackage-js is broken for Linux users because certain modules are not loaded precisely according to their file name casing.  Linux uses a case-sensitive filesystem, so this makes sense.  Mac OS X and Windows do not use case sensitive file systems, which is most likely why this hasn't been an issue until now.  Likewise, all packages that depend on geopackage-js (mapcache-server develop branch, for one), are broken for Linux users.  This commit should fix the issues so that the modules load properly on Linux, OSX, and Windows.

I tested this by running `npm test` - there may be additional places where these module loadings need to be adjusted, but I do know that mapcache-server (develop branch) at least starts up with these changes.
