### PR TITLE
Leaflet plugin updates

### DIFF
--- a/docs/leaflet/index.js
+++ b/docs/leaflet/index.js
@@ -6,7 +6,19 @@ var baseLayer = L.tileLayer('https://mapbox.geointservices.io/v4/mapbox.light/{z
 });
 baseLayer.addTo(map);
 
-L.gridLayer.geoPackage({
+L.geoPackageTileLayer({
     geoPackageUrl: 'http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg',
     layerName: 'rivers_tiles'
+}).addTo(map);
+
+L.geoPackageFeatureLayer([], {
+    geoPackageUrl: 'http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg',
+    layerName: 'rivers',
+    onEachFeature: function (feature, layer) {
+      var string = "";
+      for (var key in feature.properties) {
+        string += '<div class="item"><span class="label">' + key + ': </span><span class="value">' + feature.properties[key] + '</span></div>';
+      }
+      layer.bindPopup(string);
+    }
 }).addTo(map);

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ module.exports.iterateGeoJSONFeaturesFromTable = function(geopackage, table, fea
           var geom = geometry.geometry;
           var geoJsonGeom = geometry.geometry.toGeoJSON();
           if (srs.definition && srs.definition !== 'undefined') {
-            geoJson = reproject.reproject(geoJson, srs.organization + ':' + srs.organization_coordsys_id, 'EPSG:4326');
+            geoJsonGeom = reproject.reproject(geoJsonGeom, srs.organization + ':' + srs.organization_coordsys_id, 'EPSG:4326');
           }
         }
         var geoJson = {

--- a/leaflet/README.md
+++ b/leaflet/README.md
@@ -1,0 +1,61 @@
+## leaflet-geopackage &mdash; GeoPackage layers in Leaflet
+
+Load GeoPackage tile and feature layers in the browser without a server.  When a layer is added to the map, the GeoPackage will be downloaded and then the specified layer will be loaded on the map.
+
+### Demo
+
+[Sample Page](https://ngageoint.github.io/leaflet/index.html) which loads a tile layer and a feature layer from the [Natural Earth Rivers GeoPackage](http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg)
+
+### Usage
+
+```js
+
+// Load the Rivers GeoPackage and display the tile layer
+L.geoPackageTileLayer({
+    geoPackageUrl: 'http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg',
+    layerName: 'rivers_tiles'
+}).addTo(map);
+
+// Load the Rivers GeoPackage and display the feature layer
+L.geoPackageFeatureLayer([], {
+    geoPackageUrl: 'http://ngageoint.github.io/GeoPackage/examples/rivers.gpkg',
+    layerName: 'rivers'
+}).addTo(map);
+```
+
+### GeoPackageTileLayer Options
+
+GeoPackageTileLayer extends L.GridLayer and accepts all options for L.GridLayer in addition to the following:
+
+| option       | type    | |
+| ------------ | ------- | -------------- | -------------------------------------------------------------------------- |
+| `geoPackageUrl`     | String  | The URL to the GeoPackage
+| `layerName`   | String  | Name of the Tile Layer within the GeoPackage          |
+
+### GeoPackageFeatureLayer Options
+
+GeoPackageFeatureLayer extends L.GeoJSON and accepts all options for L.GeoJSON in addition to the following:
+
+| option       | type    | |
+| ------------ | ------- | -------------- | -------------------------------------------------------------------------- |
+| `geoPackageUrl`     | String  | The URL to the GeoPackage
+| `layerName`   | String  | Name of the Feature Layer within the GeoPackage          |
+
+### Browser builds
+
+```bash
+npm install
+npm run build-dev # development build, used by the debug page
+npm run build-min # minified production build
+```
+
+### Changelog
+
+##### 2.0.0
+
+- **Breaking**: Moved TileLayer from L.GridLayer.GeoPackage to L.GeoPackageTileLayer
+- Added L.GeoPackageFeatureLayer
+
+##### 1.0.0
+
+- Initial release.

--- a/leaflet/package.json
+++ b/leaflet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "leaflet-geopackage",
-  "version": "1.0.0",
-  "description": "Load a GeoPackage tile layer.",
+  "version": "2.0.0",
+  "description": "Load a GeoPackage layer.",
   "main": "leaflet-geopackage.js",
   "keywords": [
     "NGA",

--- a/leaflet/package.json
+++ b/leaflet/package.json
@@ -31,9 +31,12 @@
     "geopackage": "github:ngageoint/geopackage-js"
   },
   "scripts": {
+    "build-dev": "browserify leaflet-geopackage.js --exclude sqlite3 --exclude lwip --exclude inquirer -o dist/leaflet-geopackage.js",
+    "build-min": "browserify leaflet-geopackage.js --exclude sqlite3 --exclude lwip --exclude inquirer | uglifyjs -c -m -o dist/leaflet-geopackage.min.js",
     "prepublish": "browserify leaflet-geopackage.js --exclude sqlite3 --exclude lwip --exclude inquirer -o dist/leaflet-geopackage.js"
   },
   "devDependencies": {
-    "browserify": "^14.1.0"
+    "browserify": "^14.1.0",
+    "uglify-js": "^2.8.12"
   }
 }

--- a/lib/tiles/retriever/index.js
+++ b/lib/tiles/retriever/index.js
@@ -81,7 +81,7 @@ GeoPackageTileRetriever.prototype.getTileWithBounds = function (targetBoundingBo
   }
   var tiles = [];
   var tileMatrix = this.tileDao.getTileMatrixWithZoomLevel(zoom);
-
+  if (!tileMatrix) return callback();
   var tileWidth = tileMatrix.tile_width;
   var tileHeight = tileMatrix.tile_height;
 


### PR DESCRIPTION
Pulling new updates to the leaflet plugin including the ability to load a feature layer and moving the tile layer loading to a new scope.

Fixes a bug when trying to load a tile in a zoom level that does not exist.

Fixes a bug when loading features in a projection that is not EPSG:4326