### PR TITLE
Adapter should release and callback on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,77 +141,49 @@ function loadByteArray(array, callback) {
 #### NodeJS Usage ####
 
 ```javascript
-var geopackage = require('geopackage')
-  , GeoPackageManager = geopackage.GeoPackageManager
-  , GeoPackageConnection = geopackage.GeoPackageConnection
-  , GeoPackageTileRetriever = geopackage.GeoPackageTileRetriever;
+/**
+ * Split a Geopackage into GeoJSON JSON files.
+ */
+const fs = require('fs');
 
-GeoPackageManager.open(filename, function(err, geoPackage) {
+const filename = './test/data/rivers.gpkg';
+ 
+const geoPackage = require('@ngageoint/geopackage');
+const GeoPackageConnection = geoPackage.GeoPackageConnection;
+const GeoPackageTileRetriever = geoPackage.GeoPackageTileRetriever;
+
+geoPackage.openGeoPackage(filename, function(err, gpkg) {
 
   // Now you can operate on the GeoPackage
-
-  // get the tile table names
-  geoPackage.getTileTables(function(err, tileTableNames) {
-    // tileTableNames is an array of all tile table names
-
-    // get the info for the first table
-    geoPackage.getTileDaoWithTableName(tileTableNames[0], function(err, tileDao) {
-      geoPackage.getInfoForTable(tileDao, function(err, info) {
-        // do something with the tile table info
-      });
-
-      // draw a tile into a canvas for an XYZ tile
-      var canvas = canvasFromSomewhere;
-      var gpr = new GeoPackageTileRetriever(tileDao, 256, 256);
-      var x = 0;
-      var y = 0;
-      var zoom = 0;
-
-      console.time('Draw tile ' + x + ', ' + y + ' zoom: ' + zoom);
-      gpr.drawTileIn(x, y, zoom, canvas, function() {
-        console.timeEnd('Draw tile ' + x + ', ' + y + ' zoom: ' + zoom);
-      });
-
-      // or get a tile base64 data URL for an XYZ tile
-      gpr.getTile(x, y, zoom, function(err, tileBase64DataURL) {
-        console.log('got the base64 data url');
-      });
-
-      // or get a tile from a GeoPackage tile column and tile row
-      tileDao.queryForTile(tileColumn, tileRow, zoom, function(err, tile) {
-        var tileData = tile.getTileData();  // the raw bytes from the GeoPackage
-      });
-
-    });
-  });
-
   // get the feature table names
-  geoPackage.getFeatureTables(function(err, featureTableNames) {
+  gpkg.getFeatureTables(function(err, featureTableNames) {
     // featureTableNames is an array of all feature table names
 
     // get the info for the first table
-    geoPackage.getFeatureDaoWithTableName(featureTableNames[0], function(err, featureDao) {
-      geoPackage.getInfoForTable(featureDao, function(err, info) {
+    gpkg.getFeatureDaoWithTableName(featureTableNames[0], function(err, featureDao) {
+      var featureInfo;
+      gpkg.getInfoForTable(featureDao, function(err, info) {
         // do something with the feature table info
-      });
-
-      // query for all features
-      featureDao.queryForEach(function(err, row, rowDone) {
-        var feature = featureDao.getFeatureRow(row);
-        var geometry = currentRow.getGeometry();
-        if (geometry) {
-          var geom = geometry.geometry;
-          var geoJson = geometry.geometry.toGeoJSON();
-
-          geoJson.properties = {};
-          for (var key in feature.values) {
-            if(feature.values.hasOwnProperty(key) && key != feature.getGeometryColumn().name) {
-              var column = info.columnMap[key];
-              geoJson.properties[column.displayName] = currentRow.values[key];
+        featureInfo = info;
+        // query for all features
+        featureDao.queryForEach(function(err, row, rowDone) {
+          var feature = featureDao.getFeatureRow(row);
+          var geometry = feature.getGeometry();
+          if (geometry) {
+            var geom = geometry.geometry;
+            var geoJson = geometry.geometry.toGeoJSON();
+            var name = feature.values.property_1.replace(" ","_") + "_" + feature.values.property_0 + "_" + feature.values.id + ".json";
+            fs.writeFileSync('./test/data/' + name , JSON.stringify(geoJson,null,2));  
+            geoJson.properties = {};
+            for (var key in feature.values) {
+              if(feature.values.hasOwnProperty(key) && key != feature.getGeometryColumn().name) {
+                var column = featureInfo.columnMap[key];
+                geoJson.properties[column.displayName] = feature.values[key];
+              }
             }
           }
-        }
-        rowDone();
+          rowDone();
+        });
       });
     });
   });

--- a/lib/db/sqliteAdapter.js
+++ b/lib/db/sqliteAdapter.js
@@ -23,8 +23,13 @@ function Adapter(db) {
   this.db = db;
 }
 
-Adapter.prototype.close = function() {
-  this.db.close();
+Adapter.prototype.close = function(cb) {
+  if(this.db) {
+    var tdb = this.db;
+    // release native DB object
+    this.db = null;
+    tdb.close(cb);
+  }
 }
 
 Adapter.prototype.export = function(callback) {

--- a/lib/db/sqljsAdapter.js
+++ b/lib/db/sqljsAdapter.js
@@ -40,7 +40,12 @@ function Adapter(db) {
 }
 
 Adapter.prototype.close = function() {
-  this.db.close();
+  if(this.db) {
+    var tdb = this.db;
+    // release native DB object
+    this.db = null;
+    tdb.close(cb);
+  }
 }
 
 Adapter.prototype.getDBConnection = function () {

--- a/lib/db/sqljsAdapter.js
+++ b/lib/db/sqljsAdapter.js
@@ -39,7 +39,7 @@ function Adapter(db) {
   this.db = db;
 }
 
-Adapter.prototype.close = function() {
+Adapter.prototype.close = function(cb) {
   if(this.db) {
     var tdb = this.db;
     // release native DB object


### PR DESCRIPTION
All references to the DB need to be released for the destructor to be called.
Also, callback on close.
Needs more verification.
This change cleans up some EPERM errors on Win10, but not all EBUSY errors on unlink.