### PR TITLE
Fix #103

### DIFF
--- a/lib/geoPackage.js
+++ b/lib/geoPackage.js
@@ -33,6 +33,7 @@ var async = require('async')
   , proj4 = require('proj4')
   , toArray = require('stream-to-array');
 
+proj4 = 'default' in proj4 ? proj4['default'] : proj4; // Module loading hack
 var defs = require('./proj4Defs');
 for (var name in defs) {
   if (defs[name]) {

--- a/lib/geoPackage.js
+++ b/lib/geoPackage.js
@@ -35,11 +35,6 @@ var async = require('async')
 
 proj4 = 'default' in proj4 ? proj4['default'] : proj4; // Module loading hack
 var defs = require('./proj4Defs');
-for (var name in defs) {
-  if (defs[name]) {
-    proj4.defs(name, defs[name]);
-  }
-}
 
 /**
  * GeoPackage database
@@ -50,6 +45,23 @@ var GeoPackage = function(name, path, connection) {
   this.path = path;
   this.connection = connection;
   this.tableCreator = new TableCreator(this);
+}
+
+GeoPackage.loadProjections = function(items) {
+  if (!(items instanceof Array)) throw new Error('Invalid array of projections');
+  for (var i = 0; i < items.length; i++) {
+    if (!defs[items[i]]) throw new Error('Projection not found');
+    this.addProjection(items[i], defs[items[i]]);
+  }
+}
+
+GeoPackage.addProjection = function(name, definition) {
+  if (!name || ! definition) throw new Error('Invalid projection name/definition');
+  proj4.defs(''+name, ''+definition);
+}
+
+GeoPackage.hasProjection = function(name) {
+  return proj4.defs(''+name);
 }
 
 GeoPackage.prototype.close = function() {

--- a/test/lib/testGeoPackage.js
+++ b/test/lib/testGeoPackage.js
@@ -204,4 +204,39 @@ describe('GeoPackage tests', function() {
     });
   });
 
+  it('should exists default projection', function() {
+    var result = GeoPackage.hasProjection('EPSG:4326');
+    should.exist(result);
+  });
+
+  it('should throw error on invalid load projections argument', function() {
+    (function() {
+      GeoPackage.loadProjections(null);
+    }).should.throw('Invalid array of projections');
+  });
+
+  it('should throw error on unknown projection item', function() {
+    (function() {
+      GeoPackage.loadProjections([null]);
+    }).should.throw('Projection not found');
+  });
+
+  it('should load projections', function() {
+    GeoPackage.loadProjections(['EPSG:4326']);
+    var result = GeoPackage.hasProjection('EPSG:4326');
+    should.exist(result);
+  });
+
+  it('should throw error on empty add projection args', function() {
+    (function() {
+      GeoPackage.addProjection(null, null);
+    }).should.throw('Invalid projection name/definition');
+  });
+
+  it('should add projection', function() {
+    GeoPackage.addProjection('EPSG:4001', '+proj=longlat +ellps=airy +no_defs');
+    var result = GeoPackage.hasProjection('EPSG:4001');
+    should.exist(result);
+  });
+
 });


### PR DESCRIPTION
1. Ability to load only necessary proj4 definitions as well add non-existing definitions.
2. Hack to fix proj4 module loading with webpack