### PR TITLE
fix for CanvasTileCreator's chunks not being cleared out between calls to addTile

### DIFF
--- a/lib/tiles/creator/canvas.js
+++ b/lib/tiles/creator/canvas.js
@@ -43,6 +43,7 @@ CanvasTileCreator.prototype.addTile = function (tileData, gridColumn, gridRow) {
   var base64Data = btoa( binary );
 
   return new Promise(function(resolve, reject) {
+    this.chunks = [];
     this.image.onload = function() {
       resolve(this.tileContext.drawImage(this.image, 0, 0));
     }.bind(this);


### PR DESCRIPTION
Fix for an edge case problem when adding tiles to a canvas using the same CanvasTileCreator. I created a geopackage with two tiles at zoom level 18. when setting the zoom to 17 it retrieved the request, due to javascript rounding, it retrieved both tiles and added them to the variable chunks. After cutting and scaling, the tile looked normal. The next request retrieved only a single tile and added it to chunks. Chunks now had three tiles (one being a duplicate) that tile was drawn on the canvas twice and due to it's opaque nature, it appeared darker than it should have been.

Attached is the rendering issue displayed on a leaflet map.
<img width="198" alt="Screen Shot 2019-07-12 at 11 21 10 AM" src="https://user-images.githubusercontent.com/2279132/61139499-67ccc200-a497-11e9-82bd-17c09f9eec2d.png">

