### PR TITLE
update reproject to fix transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngageoint/geopackage",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2543,9 +2543,9 @@
       "dev": true
     },
     "event-stream": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
-      "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
       "requires": {
         "duplexer": "^0.1.1",
         "from": "^0.1.7",
@@ -3516,9 +3516,9 @@
       }
     },
     "geojson-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/geojson-stream/-/geojson-stream-0.0.1.tgz",
-      "integrity": "sha1-Gh1hcWcEHHMCpFRwMYFkaZdhUC8=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-stream/-/geojson-stream-0.1.0.tgz",
+      "integrity": "sha512-svSg5fFXPaTiqzEBGXScA+nISaeC9rLvku2PH+wM5LToATUw2bLIrvls43ymnT9Xnp51nBPVyK9m4Af40KpJ7w==",
       "requires": {
         "JSONStream": "^1.0.0",
         "through": "^2.3.4"
@@ -8040,17 +8040,28 @@
       }
     },
     "reproject": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.2.2.tgz",
-      "integrity": "sha512-BmXQ/Mjq6wI56aVYQh38V//5+53vHo7WKc0KY2f0s+p0Pa6D27RMLdbw2XKTvcOyaue7XOlWtz6eq6SciD3aqA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.2.5.tgz",
+      "integrity": "sha512-cTH78fi1uuv5gzW/GVepO4LbCvOUhO0X2BEyyvrKkYb4KPRmDPs7cZnIxemHPUIch/CoSI8MPLmXRHZFSHjbKw==",
       "requires": {
-        "concat-stream": "^1.5.1",
-        "event-stream": "^3.3.4",
-        "geojson-stream": "0.0.1",
+        "concat-stream": "^2.0.0",
+        "event-stream": "^4.0.0",
+        "geojson-stream": "0.1.0",
         "minimist": "^1.2.0",
         "proj4": "^2.4.4"
       },
       "dependencies": {
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -8063,6 +8074,16 @@
           "requires": {
             "mgrs": "1.0.0",
             "wkt-parser": "^1.2.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "pbf": "^3.1.0",
     "proj4": "2.4.3",
     "rbush": "2.0.2",
-    "reproject": "1.2.2",
+    "reproject": "1.2.5",
     "sql.js": "https://github.com/danielbarela/sql.js.git",
     "vt-pbf": "^3.1.1",
     "wkx": "0.4.4"


### PR DESCRIPTION
`reproject`'s previous version used an older version of `event-stream` which referenced a dependency that is no longer on npm. The patch update in `reproject` fixes that by using a newer version of `event-stream`.