### PR TITLE
Fixes for tile scaling extension

### DIFF
--- a/lib/geoPackage.ts
+++ b/lib/geoPackage.ts
@@ -1710,6 +1710,12 @@ export class GeoPackage {
     height = Number(height);
     const tileDao = this.getTileDao(table);
     const retriever = new GeoPackageTileRetriever(tileDao, width, height);
+    if (this.getTileScalingExtension(table).has()) {
+      const tileScaling = this.getTileScalingExtension(table).dao.queryForTableName(table)
+      if (tileScaling) {
+        retriever.setScaling(tileScaling)
+      }
+    }
     if (!canvas) {
       return retriever.getTile(x, y, z);
     } else {

--- a/lib/tiles/retriever/index.ts
+++ b/lib/tiles/retriever/index.ts
@@ -236,12 +236,12 @@ export class GeoPackageTileRetriever {
                 }
 
                 zoomLevels = [];
-                const maxLevels = Math.max(firstLevels.size(), secondLevels.size());
+                const maxLevels = Math.max(firstLevels.length, secondLevels.length);
                 for (let i = 0; i < maxLevels; i++) {
-                  if (i < firstLevels.size()) {
+                  if (i < firstLevels.length) {
                     zoomLevels.push(firstLevels[i]);
                   }
-                  if (i < secondLevels.size()) {
+                  if (i < secondLevels.length) {
                     zoomLevels.push(secondLevels[i]);
                   }
                 }

--- a/lib/tiles/retriever/index.ts
+++ b/lib/tiles/retriever/index.ts
@@ -113,8 +113,9 @@ export class GeoPackageTileRetriever {
     const projectedBoundingBox = targetBoundingBox.projectBoundingBox(targetProjection, this.tileDao.projection);
 
     const tileMatrices = this.getTileMatrices(projectedBoundingBox);
+    let tileFound = false;
     let tile = null;
-    for (let i = 0; !tile && i < tileMatrices.length; i++) {
+    for (let i = 0; !tileFound && i < tileMatrices.length; i++) {
       const tileMatrix = tileMatrices[i];
       const tileWidth = tileMatrix.tile_width;
       const tileHeight = tileMatrix.tile_height;
@@ -131,8 +132,9 @@ export class GeoPackageTileRetriever {
       const iterator = this.retrieveTileResults(targetBoundingBox.projectBoundingBox(targetProjection, this.tileDao.projection), tileMatrix);
       for (const tile of iterator) {
         await creator.addTile(tile.tileData, tile.tileColumn, tile.row);
+        tileFound = true;
       }
-      if (!canvas) {
+      if (!canvas && tileFound) {
         tile = creator.getCompleteTile('png');
       }
     }


### PR DESCRIPTION
There were a few issues with the tile scaling extension, specifically when using CLOSEST_IN_OUT/CLOSEST_OUT_IN. Also updated GeoPackage.xyzTile to check for tile scaling extension when retrieving tiles.