### PR TITLE
Projected Tile Updates

### DIFF
--- a/lib/tiles/creator/canvas.ts
+++ b/lib/tiles/creator/canvas.ts
@@ -68,9 +68,8 @@ export class CanvasTileCreator extends TileCreator {
   }
 
   async addTile(tileData: any, gridColumn: number, gridRow: number): Promise<void> {
-    const type = fileType(tileData);
     await this.loadImage(tileData);
-    this.projectTile(tileData, gridColumn, gridRow);
+    // This is being cut and scaled
     if (this.chunks && this.chunks.length) {
       return this.chunks.reduce((sequence, chunk) => {
         const type = fileType(tileData);
@@ -95,6 +94,9 @@ export class CanvasTileCreator extends TileCreator {
           });
         });
       }, Promise.resolve());
+    } else {
+      // otherwise, project the tile
+      return this.projectTile(tileData, gridColumn, gridRow);
     }
   }
   async getCompleteTile(): Promise<any> {
@@ -143,6 +145,7 @@ export class CanvasTileCreator extends TileCreator {
           this.tileContext.getImageData(0, 0, this.tileMatrix.tile_width, this.tileMatrix.tile_height).data.buffer,
         ]);
       } catch (e) {
+        console.error(e)
         const worker = ProjectTile;
         worker(job, function(err: any, data: any) {
           resolve(CanvasTileCreator.workerDone(data, piecePosition, ctx));

--- a/lib/tiles/creator/canvas.ts
+++ b/lib/tiles/creator/canvas.ts
@@ -70,6 +70,7 @@ export class CanvasTileCreator extends TileCreator {
   async addTile(tileData: any, gridColumn: number, gridRow: number): Promise<void> {
     await this.loadImage(tileData);
     // This is being cut and scaled
+    await this.projectTile(tileData, gridColumn, gridRow);
     if (this.chunks && this.chunks.length) {
       return this.chunks.reduce((sequence, chunk) => {
         const type = fileType(tileData);
@@ -94,9 +95,6 @@ export class CanvasTileCreator extends TileCreator {
           });
         });
       }, Promise.resolve());
-    } else {
-      // otherwise, project the tile
-      return this.projectTile(tileData, gridColumn, gridRow);
     }
   }
   async getCompleteTile(): Promise<any> {
@@ -145,7 +143,6 @@ export class CanvasTileCreator extends TileCreator {
           this.tileContext.getImageData(0, 0, this.tileMatrix.tile_width, this.tileMatrix.tile_height).data.buffer,
         ]);
       } catch (e) {
-        console.error(e)
         const worker = ProjectTile;
         worker(job, function(err: any, data: any) {
           resolve(CanvasTileCreator.workerDone(data, piecePosition, ctx));

--- a/lib/tiles/creator/canvas.ts
+++ b/lib/tiles/creator/canvas.ts
@@ -61,6 +61,7 @@ export class CanvasTileCreator extends TileCreator {
     return new Promise((resolve: Function) => {
       this.chunks = [];
       this.image.onload = (): void => {
+        this.tileContext.clearRect(0, 0, this.tileMatrix.tile_width, this.tileMatrix.tile_height);
         resolve(this.tileContext.drawImage(this.image, 0, 0));
       };
       this.image.src = 'data:' + type.mime + ';base64,' + base64Data;

--- a/lib/tiles/creator/node.ts
+++ b/lib/tiles/creator/node.ts
@@ -53,6 +53,7 @@ export class NodeTileCreator extends TileCreator {
   }
   async addTile(tileData: any, gridColumn: number, gridRow: number): Promise<any> {
     const tile = await ImageUtils.getImage(tileData);
+    this.tileContext.clearRect(0, 0, this.tileMatrix.tile_width, this.tileMatrix.tile_height);
     this.tileContext.drawImage(tile, 0, 0);
     this.chunks = [];
     await this.projectTile(tileData, gridColumn, gridRow);

--- a/lib/tiles/retriever/index.ts
+++ b/lib/tiles/retriever/index.ts
@@ -1,4 +1,3 @@
-import proj4 from 'proj4';
 import { TileDao } from '../user/tileDao';
 import { TileMatrix } from '../matrix/tileMatrix';
 import { TileBoundingBoxUtils } from '../tileBoundingBoxUtils';
@@ -52,13 +51,15 @@ export class GeoPackageTileRetriever {
     let hasTile = false;
     if (x >= 0 && y >= 0 && zoom >= 0) {
       const tilesBoundingBox = TileBoundingBoxUtils.getWebMercatorBoundingBoxFromXYZ(x, y, zoom);
-      hasTile = this.hasTileForBoundingBox(tilesBoundingBox);
+      hasTile = this.hasTileForBoundingBox(tilesBoundingBox, 'EPSG:3857');
     }
     return hasTile;
   }
 
-  hasTileForBoundingBox(tilesBoundingBox: BoundingBox): boolean {
-    const tileMatrices = this.getTileMatrices(tilesBoundingBox);
+  hasTileForBoundingBox(tilesBoundingBox: BoundingBox, targetProjection: string): boolean {
+    const projectedBoundingBox = tilesBoundingBox.projectBoundingBox(targetProjection, this.tileDao.projection);
+
+    const tileMatrices = this.getTileMatrices(projectedBoundingBox);
     let hasTile = false;
     for (let i = 0; !hasTile && i < tileMatrices.length; i++) {
       const tileMatrix = tileMatrices[i];
@@ -66,9 +67,9 @@ export class GeoPackageTileRetriever {
         this.tileDao.tileMatrixSet.boundingBox,
         tileMatrix.matrix_width,
         tileMatrix.matrix_height,
-        tilesBoundingBox,
+        projectedBoundingBox,
       );
-      hasTile = !!this.tileDao.countByTileGrid(tileGrid, tileMatrix.zoom_level);
+      hasTile = this.tileDao.countByTileGrid(tileGrid, tileMatrix.zoom_level) > 0;
     }
     return hasTile;
   }
@@ -129,10 +130,19 @@ export class GeoPackageTileRetriever {
         targetProjection,
         canvas,
       );
-      const iterator = this.retrieveTileResults(targetBoundingBox.projectBoundingBox(targetProjection, this.tileDao.projection), tileMatrix);
+      const iterator = this.retrieveTileResults(projectedBoundingBox, tileMatrix);
       for (const tile of iterator) {
-        await creator.addTile(tile.tileData, tile.tileColumn, tile.row);
-        tileFound = true;
+        // Get the bounding box of the tile
+        const tileBoundingBox = TileBoundingBoxUtils.getTileBoundingBox(this.tileDao.tileMatrixSet.boundingBox, tileMatrix, tile.tileColumn, tile.row);
+        const overlap = TileBoundingBoxUtils.intersection(projectedBoundingBox, tileBoundingBox);
+        if (overlap != null) {
+          const src = TileBoundingBoxUtils.getFloatRoundedRectangle(tileMatrix.tile_width, tileMatrix.tile_height, tileBoundingBox, overlap)
+          const dest = TileBoundingBoxUtils.getFloatRoundedRectangle(this.width, this.height, projectedBoundingBox, overlap)
+          if (src.isValid && dest.isValid) {
+            await creator.addTile(tile.tileData, tile.tileColumn, tile.row);
+            tileFound = true;
+          }
+        }
       }
       if (!canvas && tileFound) {
         tile = creator.getCompleteTile('png');

--- a/test/lib/tiles/testTileBoundingBoxUtils.js
+++ b/test/lib/tiles/testTileBoundingBoxUtils.js
@@ -1,5 +1,5 @@
 const
-    TileBoundingBoxUtils = require('../../../lib/tiles/tileBoundingBoxUtils').TileBoundingBoxUtils
+  TileBoundingBoxUtils = require('../../../lib/tiles/tileBoundingBoxUtils').TileBoundingBoxUtils
   , TileUtils = require('../../../lib/tiles/creator/tileUtilities')
   , BoundingBox = require('../../../lib/boundingBox').BoundingBox;
 
@@ -14,7 +14,7 @@ describe('TileBoundingBoxUtils tests', function() {
 
 
     var maxColumn = TileBoundingBoxUtils.getTileColumnWithTotalBoundingBox(totalBox, tileMatrixWidth, longitude, true);
-    maxColumn.should.be.equal(2);
+    maxColumn.should.be.equal(3);
     done();
   });
 


### PR DESCRIPTION
This pull request is for some changes that address three projection issues:

1. when a projection has more than one source tile in the destination tile, the addTile function is called multiple times. This draws the source tile into a context that is reused. that context needs to be cleared out before drawing the subsequent source tiles.
2. the call to projectTile wasn't being awaited and would run asynchronously. This works fine when loading tiles onto a map but caused a timing issue for requesting a tile and immediately using the result (as it may not have finished projecting).
3. the hasTile call was not projecting the requested bounding box into the source projection before checking if a tile existed.