### PR TITLE
Geojson Null Geometry

### DIFF
--- a/converters/geojson/test/fixtures/nullGeometry.geojson
+++ b/converters/geojson/test/fixtures/nullGeometry.geojson
@@ -1,0 +1,12 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "id": "58efd907c0f7921f25d0f5a1"
+      }
+    }
+  ]
+}

--- a/converters/geojson/test/testIndex.js
+++ b/converters/geojson/test/testIndex.js
@@ -378,4 +378,19 @@ describe('GeoJSON to GeoPackage tests', function() {
       });
     });
   });
+
+  it('should convert geoJSON with null geometries', function (){
+    try {
+      fs.unlinkSync(path.join(__dirname, 'fixtures', 'tmp', 'nullGeometry.gpkg'));
+    } catch (e) {}
+    const converter = new GeoJSONToGeoPackage();
+    // console.log(path.join(__dirname, 'fixtures', 'nullGeometry.json'));
+    return converter.convert({geoJson: path.join(__dirname, 'fixtures', 'nullGeometry.geojson'), geoPackage: path.join(__dirname, 'fixtures', 'tmp', 'nullGeometry.gpkg')},(t) => console.log(t))
+    .then(function(geopackage) {
+      should.exist(geopackage);
+      var tables = geopackage.getFeatureTables();
+      tables.length.should.be.equal(1);
+      tables[0].should.be.equal('nullGeometry');
+    });
+  });
 });

--- a/lib/geoPackage.ts
+++ b/lib/geoPackage.ts
@@ -636,8 +636,13 @@ export class GeoPackage {
     }
 
     const featureGeometry = typeof feature.geometry === 'string' ? JSON.parse(feature.geometry) : feature.geometry;
-    const geometry = wkx.Geometry.parseGeoJSON(featureGeometry);
-    geometryData.setGeometry(geometry);
+    if (featureGeometry !== null) {
+      const geometry = wkx.Geometry.parseGeoJSON(featureGeometry);
+      geometryData.setGeometry(geometry);
+    } else {
+      const temp = wkx.Geometry.parse('POINT EMPTY');
+      geometryData.setGeometry(temp);
+    }
     featureRow.geometry = geometryData;
     for (const propertyKey in feature.properties) {
       if (Object.prototype.hasOwnProperty.call(feature.properties, propertyKey)) {


### PR DESCRIPTION
Added the ability for `Geopackage.addGeoJSONFeatureToGeoPackage(...)`  to handle null geometries. It treat them as the wkt `POINT EMPTY`.