### PR TITLE
4.2.8 update better-sqlite3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
         JOB_CONTEXT: ${{ toJson(matrix) }}
       run: echo "$JOB_CONTEXT"
     - name: Coveralls
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '24.x'
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+##### 4.2.8
+- Update [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) version constraint to allow major versions 9-12.
+- Fix dangling error response for image http request.
+
 ##### 4.2.7
 
 - Upgrade the [`inquirer`](https://www.npmjs.com/package/inquirer) dependency to address [CVE-2025-54798](https://github.com/advisories/GHSA-52f5-9888-hmc6), and [CVE-2026-44705](https://github.com/advisories/GHSA-ph9p-34f9-6g65)

--- a/lib/canvas/canvasKitCanvasAdapter.ts
+++ b/lib/canvas/canvasKitCanvasAdapter.ts
@@ -87,6 +87,7 @@ export class CanvasKitCanvasAdapter implements CanvasAdapter {
               } else {
                 reject('Code: ' + res.statusCode);
               }
+              res.resume();
             })
           });
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ngageoint/geopackage",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ngageoint/geopackage",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "license": "MIT",
       "dependencies": {
         "@turf/bbox": "6.3.0",
@@ -75,7 +75,7 @@
         "xhr-mock": "2.5.1"
       },
       "optionalDependencies": {
-        "better-sqlite3": "^9.1.1",
+        "better-sqlite3": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
         "chalk": "4.1.1",
         "inquirer": "^14.0.0"
       }
@@ -2200,15 +2200,18 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/big.js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngageoint/geopackage",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "GeoPackage JavaScript Library",
   "keywords": [
     "NGA",
@@ -89,7 +89,7 @@
     "xhr-mock": "2.5.1"
   },
   "optionalDependencies": {
-    "better-sqlite3": "^9.1.1",
+    "better-sqlite3": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
     "chalk": "4.1.1",
     "inquirer": "^14.0.0"
   },


### PR DESCRIPTION
- Update [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) version constraint to allow major versions 9-12.
- Fix dangling error response for image http request.
- Bump patch version to 4.2.8.